### PR TITLE
Update IT professionals document to mention TCP port 8883

### DIFF
--- a/v13/Extras/troubleshooting/for-it-security-professionals.md
+++ b/v13/Extras/troubleshooting/for-it-security-professionals.md
@@ -10,7 +10,9 @@ FarmBot requires access to various servers to operate properly.
 
 The first server is the web server (HTTPS). The servers are operated in the United States by Heroku, a Salesforce subsidiary. Heroku subcontracts their infrastructure services to Amazon Web Services (AWS). The servers reside in Amazon's `us-east-1` region, which is located in Virginia. The server uses the domains `my.farm.bot` and `my.farmbot.io`. Both domains point to the same server. Services are provided on TCP port 443 (HTTPS and WSS). Heroku does not provide lists of IP ranges, but they should mirror Amazon's us-east-1 IP ranges. We do not have control over IP allocation, but the most up-to-date list can be found [here](https://docs.aws.amazon.com/general/latest/gr/aws-ip-ranges.html). Our DNS server is `herokudns.com`.
 
-The second server is the real-time message broker, which runs the RabbitMQ software package. It is also hosted on Amazon Web Services United States region by CloudAMQP, a hosting provider specializing in RabbitMQ message brokers. Like our web servers, the message broker is hosted within Amazon's `us-east-1` data center. The server's public domain name is `clever-octopus.rmq.cloudamqp.com`. Web browsers require *long-running access* to this server on TCP port 443. FarmBot devices require long-running access to this domain on TCP port 5672.
+The second server is the real-time message broker, which runs the RabbitMQ software package. It is also hosted on Amazon Web Services United States region by CloudAMQP, a hosting provider specializing in RabbitMQ message brokers. Like our web servers, the message broker is hosted within Amazon's `us-east-1` data center. The server's public domain name is `clever-octopus.rmq.cloudamqp.com`. Web browsers require *long-running access* to this server on TCP port 443. FarmBot devices require long-running access to this domain on TCP port 5672 nd 8883.
+
+**New FarmBot OS port requirement (March 2021):** FarmBot requires access to TCP port 8883. This port is used for MQTT. You must enable this port prior to upgrading to FBOS versions above 13.0.1. Please update port restrictions as quickly as possible, as upgrades are mandatory for continued device operation on the publicly hosted server at my.farm.bot.
 
 {%
 include callout.html
@@ -35,7 +37,7 @@ The servers in the list above do not require long-running access. They simply op
 
 # Security practices
 
-Data in transit is encrypted via SSL and HTTPS (WSS:// in the case of WebSockets). AMQP traffic uses TLS managed by CloudAMQP. The web application implements an HTTP content security policy (CSP) to avoid exfiltration of data by malicious scripts on the end user's machine. Software updates are run at least once a month. Our source control hosting vendor (Github) provides us with real-time security alerts when vulnerabilities are found in libraries used by the application. Staff is on-call 24 hours a day to apply security patches. The authenticity of the server's HTTPS certificate is managed by Let's Encrypt, our certificate authority. Passwords are hashed using [Devise](https://github.com/plataformatec/devise), the most common user authentication library for Ruby on Rails applications.
+Data in transit is encrypted via SSL and HTTPS (WSS:// in the case of WebSockets). MQTT traffic uses TLS managed by CloudAMQP. The web application implements an HTTP content security policy (CSP) to avoid exfiltration of data by malicious scripts on the end user's machine. Software updates are run at least once a month. Our source control hosting vendor (Github) provides us with real-time security alerts when vulnerabilities are found in libraries used by the application. Staff is on-call 24 hours a day to apply security patches. The authenticity of the server's HTTPS certificate is managed by Let's Encrypt, our certificate authority. Passwords are hashed using [Devise](https://github.com/plataformatec/devise), the most common user authentication library for Ruby on Rails applications.
 
 # IP addressing
 
@@ -43,11 +45,11 @@ FarmBot does not require a fixed IP address. DHCP is the preferred method of ass
 
 # Proxy servers
 
-As of November 2019, **FarmBot does not support the use of proxy servers**, although we do plan to support the use of proxies in a future version of FarmBot OS. Please see this [discussion on Github](https://github.com/FarmBot/farmbot_os/issues/909) for more information.
+As of April 2021, **FarmBot does not support the use of proxy servers**, although we do plan to support the use of proxies in a future version of FarmBot OS. Please see this [discussion on Github](https://github.com/FarmBot/farmbot_os/issues/909) for more information.
 
 # Rogue access points
 
-Some users, particularly schools and larger organizations, have reported their devices as being blacklisted by their security software because the security software categorizes it as a ["rogue access point"](https://en.wikipedia.org/wiki/Rogue_access_point). Please ensure that your security software does not identify FarmBot's WiFi configurator as a rogue access point.
+Some users, particularly schools and larger organizations, have reported their devices as being block listed by their security software because the security software categorizes it as a ["rogue access point"](https://en.wikipedia.org/wiki/Rogue_access_point). Please ensure that your security software does not identify FarmBot's WiFi configurator as a rogue access point.
 
 # Enterprise WiFi
 


### PR DESCRIPTION
This PR updates references to AMQP to now mention MQTT (since we are transitioning off of AMQP entirely).

It also updates some minor things elsewhere that have not been updated in a while.